### PR TITLE
feat: scroll position keeper

### DIFF
--- a/_web/src/lib/ui/Code.svelte
+++ b/_web/src/lib/ui/Code.svelte
@@ -24,6 +24,7 @@
 
   export let watchErr = false;
   let err = false;
+  let errmsg = "";
   let success = false;
 
   let editor: Editor;
@@ -87,7 +88,13 @@
       if (getValue == value) {
         return;
       }
-      editor.setValue(value);
+      if (!err) {
+        scroll = editor.getScrollInfo();
+        editor.setValue(value);
+        editor.scrollTo(scroll["left"],scroll["top"]);
+      } else {
+        errmsg = v[watchCode];
+      }
 
       // get result
       if (getResult) {
@@ -160,6 +167,13 @@
         style="width:100%;height:100%"
         title="view html"
       />
+    {/if}
+    {#if err }
+      <div
+        class={`px-1 bg-neutral-100 dark:bg-neutral-800 dark:text-neutral-300 border-b border-neutral-200 dark:border-neutral-600 flex flex-row items-center justify-between !bg-red-400 !dark:bg-red-400 !text-neutral-800`}
+      >
+        <div class="leading-normal">{errmsg}</div>
+      </div>
     {/if}
   </div>
 </div>


### PR DESCRIPTION
Add a scroll position keeper to prevent the scroll from returning to the top when the output is refreshed.

![ezgif-4-bb43c14ec9](https://github.com/rytsh/repeatit/assets/12230071/422608f8-ebb7-40c0-8f91-f1ff0f42b7d8)
